### PR TITLE
Fix parse error

### DIFF
--- a/scripts/pre_install.php
+++ b/scripts/pre_install.php
@@ -5,7 +5,7 @@ function pre_install(){
 		mkdir(dirname('custom/'.$detailviewdefs), 0777, true);
 		copy($detailviewdefs,'custom/'.$detailviewdefs);
 	}
-	$include_js = PHP_EOL.'<?php $viewdefs["Contacts"]["EditView"]["templateMeta"]["includes"][]["file"] = "custom/modules/Contacts/js/contact_lead_autocomplete.js"; ?>';
+	$include_js = PHP_EOL.'$viewdefs["Contacts"]["EditView"]["templateMeta"]["includes"][]["file"] = "custom/modules/Contacts/js/contact_lead_autocomplete.js";' . PHP_EOL;
 	$fw = fopen('custom/'.$detailviewdefs,"a");
 	fwrite($fw,$include_js);
 	fclose($fw);
@@ -16,7 +16,7 @@ function pre_install(){
 		mkdir(dirname('custom/'.$detailviewdefs), 0777, true);
 		copy($detailviewdefs,'custom/'.$detailviewdefs);
 	}
-	$include_js = PHP_EOL.'<?php $viewdefs["Leads"]["EditView"]["templateMeta"]["includes"][]["file"] = "custom/modules/Leads/js/contact_lead_autocomplete.js"; ?>';
+	$include_js = PHP_EOL.'$viewdefs["Leads"]["EditView"]["templateMeta"]["includes"][]["file"] = "custom/modules/Leads/js/contact_lead_autocomplete.js";' . PHP_EOL;
 	$fw = fopen('custom/'.$detailviewdefs,"a");
 	fwrite($fw,$include_js);
 	fclose($fw);
@@ -27,7 +27,7 @@ function pre_install(){
 		mkdir(dirname('custom/'.$detailviewdefs), 0777, true);
 		copy($detailviewdefs,'custom/'.$detailviewdefs);
 	}
-	$include_js = PHP_EOL.'<?php $viewdefs["Accounts"]["EditView"]["templateMeta"]["includes"][]["file"] = "custom/modules/Accounts/js/account_autocomplete.js"; ?>';
+	$include_js = PHP_EOL.'$viewdefs["Accounts"]["EditView"]["templateMeta"]["includes"][]["file"] = "custom/modules/Accounts/js/account_autocomplete.js";'.PHP_EOL;
 	$fw = fopen('custom/'.$detailviewdefs,"a");
 	fwrite($fw,$include_js);
 	fclose($fw);


### PR DESCRIPTION
Fix parse error caused by php start tags in the contacts leads and accounts editviewdefs.php.  Php tags were already open.
